### PR TITLE
workflows: Use new custom runners from github

### DIFF
--- a/.github/workflows/clang-tests.yml
+++ b/.github/workflows/clang-tests.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   check_clang:
     name: Test clang,lldb,libclc
-    uses: llvm/llvm-project/.github/workflows/llvm-project-tests.yml@release/14.x
+    uses: ./.github/workflows/llvm-project-tests.yml
     with:
       build_target: check-clang
       projects: clang;lldb;libclc

--- a/.github/workflows/libclang-abi-tests.yml
+++ b/.github/workflows/libclang-abi-tests.yml
@@ -75,7 +75,7 @@ jobs:
 
   abi-dump:
     needs: abi-dump-setup
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04-llvm
     strategy:
       matrix:
         name:

--- a/.github/workflows/libclc-tests.yml
+++ b/.github/workflows/libclc-tests.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   check_libclc:
     name: Test libclc
-    uses: llvm/llvm-project/.github/workflows/llvm-project-tests.yml@release/14.x
+    uses: ./.github/workflows/llvm-project-tests.yml
     with:
       build_target: ''
       projects: clang;libclc

--- a/.github/workflows/lld-tests.yml
+++ b/.github/workflows/lld-tests.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   check_lld:
     name: Test lld
-    uses: llvm/llvm-project/.github/workflows/llvm-project-tests.yml@release/14.x
+    uses: ./.github/workflows/llvm-project-tests.yml
     with:
       build_target: check-lld
       projects: lld

--- a/.github/workflows/lldb-tests.yml
+++ b/.github/workflows/lldb-tests.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   build_lldb:
     name: Build lldb
-    uses: llvm/llvm-project/.github/workflows/llvm-project-tests.yml@release/14.x
+    uses: ./.github/workflows/llvm-project-tests.yml
     with:
       build_target: ''
       projects: clang;lldb

--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -31,8 +31,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
-          - windows-latest
+          - ubuntu-20.04-llvm
+          - windows-2022-llvm
           # Use a specific version of macOS to ensure the CPLUS_INCLUDE_PATH workaround works.
           - macOS-10.15
     steps:

--- a/.github/workflows/llvm-tests.yml
+++ b/.github/workflows/llvm-tests.yml
@@ -23,27 +23,11 @@ concurrency:
 
 jobs:
   check_all:
-    name: Test llvm,clang,libclc
-    uses: llvm/llvm-project/.github/workflows/llvm-project-tests.yml@release/14.x
+    name: Test llvm,clang,lld,lldb,libclc
+    uses: ./.github/workflows/llvm-project-tests.yml
     with:
       build_target: check-all
-      projects: clang;libclc
-
-  # These need to be separate from the check_all job, becuase there is not enough disk
-  # space to build all these projects on Windows.
-  build_lldb:
-    name: Build lldb
-    uses: llvm/llvm-project/.github/workflows/llvm-project-tests.yml@release/14.x
-    with:
-      build_target: ''
-      projects: clang;lldb
-
-  check_lld:
-    name: Test lld
-    uses: llvm/llvm-project/.github/workflows/llvm-project-tests.yml@release/14.x
-    with:
-      build_target: check-lld
-      projects: lld
+      projects: clang;lld;lldb;libclc
 
   abi-dump-setup:
     runs-on: ubuntu-latest
@@ -77,7 +61,7 @@ jobs:
 
   abi-dump:
     needs: abi-dump-setup
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04-llvm
     strategy:
       matrix:
         name:


### PR DESCRIPTION
Github now provides custom runners for us to use with more CPU,
memory, and disk, so we are switching from the default runners
to 8 core runners for Linux and Windows.  This change also allows
us to consolidate jobs now that we have runners with more disk space.
