### PR TITLE
[Support] Workaround compiler bug in MSVC

### DIFF
--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -46,6 +46,14 @@ jobs:
         uses: llvm/actions/setup-windows@main
         with:
           arch: amd64
+      # On Windows, starting with win19/20220814.1, cmake choose the 32-bit
+      # python3.10.6 libraries instead of the 64-bit libraries when building
+      # lldb.  Using this setup-python action to make 3.10 the default
+      # python fixes this.
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
       - name: Install Ninja
         uses: llvm/actions/install-ninja@main
       # actions/checkout deletes any existing files in the new git directory,

--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -34,9 +34,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          # Use windows-2019 due to:
-          # https://developercommunity.visualstudio.com/t/Prev-Issue---with-__assume-isnan-/1597317
-          - windows-2019
+          - windows-latest
           # We're using a specific version of macOS due to:
           # https://github.com/actions/virtual-environments/issues/5900
           - macOS-11

--- a/llvm/lib/Support/NativeFormatting.cpp
+++ b/llvm/lib/Support/NativeFormatting.cpp
@@ -262,5 +262,17 @@ size_t llvm::getDefaultPrecision(FloatStyle Style) {
   case FloatStyle::Percent:
     return 2; // Number of decimal places.
   }
+
+  // Workaround for MSVC bug in VS2022:
+  // https://developercommunity.visualstudio.com/t/Prev-Issue---with-__assume-isnan-/1597317
+  // llvm_unreachable expands to __assume(false) with MSVC which triggers the
+  // bug.
+#if _MSC_VER >= 1930
+  // This function is typically used in !NDEBUG builds, but we need something
+  // here to avoid 'not all control paths return a value' warnings.
+  ::llvm::llvm_unreachable_internal("Unknown FloatStyle enum", __FILE__,
+                                    __LINE__);
+#else
   llvm_unreachable("Unknown FloatStyle enum");
+#endif
 }


### PR DESCRIPTION
https://developercommunity.visualstudio.com/t/Prev-Issue---with-__assume-isnan-/1597317

This was causing unittest failures on Windows for the GitHub actions
based CI we use in the release branches.

Failed Tests (2):
  LLVM-Unit :: Support/./SupportTests.exe/FormatVariadicTest.BigTest
  LLVM-Unit :: Support/./SupportTests.exe/NativeFormatTest.BoundaryTests

Reviewed By: RKSimon, stella.stamenova

Differential Revision: https://reviews.llvm.org/D129822