### PR TITLE
mips{64}el: fix undeclared function 'syscall'

### DIFF
--- a/compiler-rt/lib/builtins/clear_cache.c
+++ b/compiler-rt/lib/builtins/clear_cache.c
@@ -6,6 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
++#if defined(__linux__) && defined(__mips__)
++// Otherwise, the build fails as it cannot find syscall
++#define _GNU_SOURCE
++#endif
+
 #include "int_lib.h"
 #if defined(__linux__)
 #include <assert.h>


### PR DESCRIPTION
Upstreaming @sylvestre's patch https://salsa.debian.org/pkg-llvm-team/llvm-toolchain/-/commit/bbdeb8c37a5d9ce5778ddf5a90b35b03dbc8355b

fix https://github.com/llvm/llvm-project/issues/57397

cc @tru