### PR TITLE
workflows: Fix libclc build failure on MacOS after 4bd3f3759259548e15…

### DIFF
--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -82,7 +82,7 @@ jobs:
           # This should be a no-op for non-mac OSes
           PKG_CONFIG_PATH: /usr/local/Homebrew/Library/Homebrew/os/mac/pkgconfig//12
         with:
-          cmake_args: '-GNinja -DLLVM_ENABLE_PROJECTS="${{ inputs.projects }}" -DCMAKE_BUILD_TYPE=Release -DLLDB_INCLUDE_TESTS=OFF -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache'
+          cmake_args: "-GNinja -DLLVM_ENABLE_PROJECTS='${{ inputs.projects }}' -DCMAKE_BUILD_TYPE=Release -DLLDB_INCLUDE_TESTS=OFF -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache ${{ startsWith(matrix.os, 'macOS') && '-DLLVM_USE_STATIC_ZSTD=TRUE' || '' }}"
           build_target:  '${{ inputs.build_target }}'
 
       - name: Build and Test libclc


### PR DESCRIPTION
…9aeba5c76efb9a0864e6fa

This is just a workaround.  I think the problem is that libclc is pulling the lzstd library name from llvm-config, but isn't also getting its install path (/usr/local/lib/).  I think the correct way to fix this is for libclc to start using the cmake files instead of llvm-config.

# **DO NOT FILE A PULL REQUEST**

This repository does not accept pull requests. Please follow http://llvm.org/docs/Contributing.html#how-to-submit-a-patch for contribution to LLVM.

# **DO NOT FILE A PULL REQUEST**
