### PR TITLE
workflows: Fix libclc tests

### DIFF
--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -90,6 +90,6 @@ jobs:
         run: |
           # Make sure all of LLVM libraries that llvm-config needs are built.
           ninja -C build
-          cmake -G Ninja -S libclc -B libclc-build -DLLVM_CONFIG=`pwd`/build/bin/llvm-config -DLIBCLC_TARGETS_TO_BUILD="amdgcn--;amdgcn--amdhsa;r600--;nvptx--;nvptx64--;nvptx--nvidiacl;nvptx64--nvidiacl"
+          cmake -G Ninja -S libclc -B libclc-build -DLLVM_DIR=`pwd`/build/lib/cmake/llvm -DLIBCLC_TARGETS_TO_BUILD="amdgcn--;amdgcn--amdhsa;r600--;nvptx--;nvptx64--;nvptx--nvidiacl;nvptx64--nvidiacl"
           ninja -C libclc-build
           ninja -C libclc-build test

--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Install Ninja
         uses: llvm/actions/install-ninja@main
       # actions/checkout deletes any existing files in the new git directory,

--- a/.github/workflows/version-check.py
+++ b/.github/workflows/version-check.py
@@ -16,7 +16,7 @@ def get_version_from_tag(tag):
 
     m = re.match('llvmorg-([0-9]+)-init', tag)
     if m:
-        return (int(m.group(1)) + 1, 0, 0)
+        return (m.group(1), "0", "0")
 
     raise Exception(f"error: Tag is not valid: {tag}")
 

--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.13.4)
 
 project( libclc VERSION 0.2.0 LANGUAGES CXX C)
 
+set(CMAKE_CXX_STANDARD 17)
+
 include( GNUInstallDirs )
 set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
   amdgcn-amdhsa/lib/SOURCES;

--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -103,7 +103,10 @@ endif()
 
 enable_language( CLC LLAsm )
 # This needs to be set before any target that needs it
-include_directories( ${LLVM_INCLUDE_DIR} )
+# We need to use LLVM_INCLUDE_DIRS here, because if we are linking to an
+# llvm build directory, this includes $src/llvm/include which is where all the
+# headers are not $build/include/ which is what LLVM_INCLUDE_DIR is set to.
+include_directories( ${LLVM_INCLUDE_DIRS} )
 
 # Setup prepare_builtins tools
 set(LLVM_LINK_COMPONENTS


### PR DESCRIPTION
libclc requires using cmake files to detect the LLVM installation instead of llvm-config so we need to update our cmake invocation.

# **DO NOT FILE A PULL REQUEST**

This repository does not accept pull requests. Please follow http://llvm.org/docs/Contributing.html#how-to-submit-a-patch for contribution to LLVM.

# **DO NOT FILE A PULL REQUEST**
