### PR TITLE
[libc++][mdspan] Fix layout_left::stride(r)

### DIFF
--- a/libcxx/include/__mdspan/layout_left.h
+++ b/libcxx/include/__mdspan/layout_left.h
@@ -164,7 +164,7 @@ public:
     _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(
         __r < extents_type::rank(), "layout_left::mapping::stride(): invalid rank index");
     index_type __s = 1;
-    for (rank_type __i = extents_type::rank() - 1; __i > __r; __i--)
+    for (rank_type __i = 0; __i < __r; __i++)
       __s *= __extents_.extent(__i);
     return __s;
   }

--- a/libcxx/test/std/containers/views/mdspan/layout_left/stride.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/layout_left/stride.pass.cpp
@@ -39,8 +39,8 @@ constexpr bool test() {
   constexpr size_t D = std::dynamic_extent;
   test_stride<std::extents<unsigned, D>>(std::array<unsigned, 1>{1}, 7);
   test_stride<std::extents<unsigned, 7>>(std::array<unsigned, 1>{1});
-  test_stride<std::extents<unsigned, 7, 8>>(std::array<unsigned, 2>{8, 1});
-  test_stride<std::extents<int64_t, D, 8, D, D>>(std::array<int64_t, 4>{720, 90, 10, 1}, 7, 9, 10);
+  test_stride<std::extents<unsigned, 7, 8>>(std::array<unsigned, 2>{1, 7});
+  test_stride<std::extents<int64_t, D, 8, D, D>>(std::array<int64_t, 4>{1, 7, 56, 504}, 7, 9, 10);
   return true;
 }
 


### PR DESCRIPTION
It was using the stride calculation of layout_right.

Reviewed By: philnik

Differential Revision: https://reviews.llvm.org/D157065