### PR TITLE
Backport 17.x : [mlir][nfc] Allow ops to have operands/attributes named `context`.

### DIFF
--- a/mlir/include/mlir/IR/OperationSupport.h
+++ b/mlir/include/mlir/IR/OperationSupport.h
@@ -555,7 +555,7 @@ public:
                                              StringRef name) final {
       if constexpr (hasProperties) {
         auto concreteOp = cast<ConcreteOp>(op);
-        return ConcreteOp::getInherentAttr(concreteOp.getContext(),
+        return ConcreteOp::getInherentAttr(concreteOp->getContext(),
                                            concreteOp.getProperties(), name);
       }
       // If the op does not have support for properties, we dispatch back to the
@@ -576,7 +576,7 @@ public:
     void populateInherentAttrs(Operation *op, NamedAttrList &attrs) final {
       if constexpr (hasProperties) {
         auto concreteOp = cast<ConcreteOp>(op);
-        ConcreteOp::populateInherentAttrs(concreteOp.getContext(),
+        ConcreteOp::populateInherentAttrs(concreteOp->getContext(),
                                           concreteOp.getProperties(), attrs);
       }
     }


### PR DESCRIPTION
900e6fcf982a is important to back port because it'll help adopting MLIR "properties" which became the default in LLVM 18

Reviewed By: mehdi_amini

Differential Revision: https://reviews.llvm.org/D159185